### PR TITLE
Feature/visibility

### DIFF
--- a/heroic_api/models.py
+++ b/heroic_api/models.py
@@ -199,8 +199,6 @@ class InstrumentCapability(models.Model):
 
 class TargetTypes(models.TextChoices):
     ICRS = 'ICRS', _('ICRS')
-    HOUR_ANGLE = 'HOUR_ANGLE', _('Hour Angle')
-    SATELLITE = 'SATELLITE', _('Satellite')
     MPC_MINOR_PLANET = 'MPC_MINOR_PLANET', _('MPC Minor Planet')
     MPC_COMET = 'MPC_COMET', _('MPC Comet')
     JPL_MAJOR_PLANET = 'JPL_MAJOR_PLANET', _('JPL Major Planet')

--- a/heroic_api/models.py
+++ b/heroic_api/models.py
@@ -195,3 +195,12 @@ class InstrumentCapability(models.Model):
     @property
     def observatory(self):
         return self.instrument.observatory
+
+
+class TargetTypes(models.TextChoices):
+    ICRS = 'ICRS', _('ICRS')
+    HOUR_ANGLE = 'HOUR_ANGLE', _('Hour Angle')
+    SATELLITE = 'SATELLITE', _('Satellite')
+    MPC_MINOR_PLANET = 'MPC_MINOR_PLANET', _('MPC Minor Planet')
+    MPC_COMET = 'MPC_COMET', _('MPC Comet')
+    JPL_MAJOR_PLANET = 'JPL_MAJOR_PLANET', _('JPL Major Planet')

--- a/heroic_api/serializers.py
+++ b/heroic_api/serializers.py
@@ -164,10 +164,6 @@ class TargetVisibilityQuerySerializer(serializers.Serializer):
         'epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion',
         'mean_distance', 'eccentricity', 'mean_anomaly', 'daily_motion'
     ]
-    SATELLITE_FIELDS = [
-        'diff_altitude_rate', 'diff_azimuth_rate', 'diff_altitude_acceleration', 'diff_azimuth_acceleration',
-        'diff_epoch', 'altitude', 'azimuth'
-    ]
     # Base fields
     telescopes = serializers.SlugRelatedField(
         slug_field='id', queryset=Telescope.objects.all(), many=True, allow_null=True
@@ -282,6 +278,8 @@ class TargetVisibilityQuerySerializer(serializers.Serializer):
                 missing_major = len(missing_major_planet_fields)
                 missing_fields = []
                 # We are missing some fields of an orbital element target or missing a target completely
+                # Sort by which orbital element scheme is missing the least fields
+                # But prioritize minor -> comet -> major if missing fields are equal
                 if (missing_minor <= missing_comet and
                     missing_minor <= missing_major and
                     missing_minor < len(self.MINOR_PLANET_FIELDS)):

--- a/heroic_api/serializers.py
+++ b/heroic_api/serializers.py
@@ -214,37 +214,6 @@ class TargetVisibilityQuerySerializer(serializers.Serializer):
     )
     epoch = serializers.FloatField(max_value=2100.0, default=2000.0, required=False, help_text=_('Epoch in MJD'))
 
-    ## hour_angle/dec targets
-    hour_angle = serializers.FloatField(required=False, help_text=_('Hour angle of the target'))
-
-    ## altitude/azimuth (satellite) targets
-    altitude = serializers.FloatField(
-        min_value=0.0, max_value=90.0, required=False, help_text=_('Altitude of the target')
-    )
-    azimuth = serializers.FloatField(
-        min_value=0.0, max_value=360.0, required=False, help_text=_('Azimuth of the target')
-    )
-    diff_altitude_rate = serializers.FloatField(
-        required=False,
-        help_text=_('Differential altitude rate in arcsec/s')
-    )
-    diff_azimuth_rate = serializers.FloatField(
-        required=False,
-        help_text=_('Differential azimuth rate in arcsec/s')
-    )
-    diff_epoch = serializers.FloatField(
-        required=False,
-        help_text=_('Reference time for non-sidereal motion in MJD')
-    )
-    diff_altitude_acceleration = serializers.FloatField(
-        required=False,
-        help_text=_('Differential altitude acceleration in arcsec/s^2')
-    )
-    diff_azimuth_acceleration = serializers.FloatField(
-        required=False,
-        help_text=_('Differential azimuth acceleration in arcsec/s^2')
-    )
-
     ## Non-sidereal targets
     epoch_of_elements = serializers.FloatField(
         min_value=10000.0, max_value=100000.0, required=False,
@@ -296,15 +265,6 @@ class TargetVisibilityQuerySerializer(serializers.Serializer):
         # Make sure that a valid target was submitted
         if validated_data.get('ra') and validated_data.get('dec'):
             validated_data['target_type'] = TargetTypes.ICRS.name
-        elif validated_data.get('hour_angle') and validated_data.get('dec'):
-            validated_data['target_type'] = TargetTypes.HOUR_ANGLE.name
-        elif validated_data.get('altitude') and validated_data.get('azimuth'):
-            validated_data['target_type'] = TargetTypes.SATELLITE.name
-            missing_fields = [field for field in self.SATELLITE_FIELDS if field not in validated_data]
-            if missing_fields:
-                raise serializers.ValidationError(
-                    {field: _('This field is required for altitude/azimuth targets') for field in missing_fields}
-                )
         else:
             # Check how many if any fields are missing from the orbital element types to see what error to return
             missing_minor_planet_fields = [field for field in self.MINOR_PLANET_FIELDS if field not in validated_data]

--- a/heroic_api/serializers.py
+++ b/heroic_api/serializers.py
@@ -1,6 +1,7 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from .models import (Observatory, Site, Telescope, Instrument, TelescopeStatus, InstrumentCapability,
-                     Profile)
+                     Profile, TargetTypes)
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -38,7 +39,7 @@ class InstrumentSerializer(serializers.ModelSerializer):
         validated_data = super().validate(data)
         split_id = validated_data.get('id', '').rsplit('.', 1)
         if len(split_id) != 2 or split_id[0] != validated_data.get('telescope').id:
-            raise serializers.ValidationError("Instrument id must follow the format 'observatory.site.telescope.instrument'")
+            raise serializers.ValidationError(_("Instrument id must follow the format 'observatory.site.telescope.instrument'"))
 
         return validated_data
 
@@ -86,7 +87,7 @@ class TelescopeSerializer(serializers.ModelSerializer):
         validated_data = super().validate(data)
         split_id = validated_data.get('id', '').rsplit('.', 1)
         if len(split_id) != 2 or split_id[0] != validated_data.get('site').id:
-            raise serializers.ValidationError("Telescope id must follow the format 'observatory.site.telescope'")
+            raise serializers.ValidationError(_("Telescope id must follow the format 'observatory.site.telescope'"))
 
         return validated_data
 
@@ -138,7 +139,7 @@ class SiteSerializer(serializers.ModelSerializer):
         validated_data = super().validate(data)
         split_id = validated_data.get('id', '').rsplit('.', 1)
         if len(split_id) != 2 or split_id[0] != validated_data.get('observatory').id:
-            raise serializers.ValidationError("Site id must follow the format 'observatory.site'")
+            raise serializers.ValidationError(_("Site id must follow the format 'observatory.site'"))
 
         return validated_data
 
@@ -148,3 +149,198 @@ class ObservatorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Observatory
         fields = '__all__'
+
+
+class TargetVisibilityQuerySerializer(serializers.Serializer):
+    MINOR_PLANET_FIELDS = [
+        'epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion',
+        'mean_distance', 'eccentricity', 'mean_anomaly'
+    ]
+    COMET_FIELDS = [
+        'epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion',
+        'perihelion_distance', 'eccentricity', 'epoch_of_perihelion'
+    ]
+    MAJOR_PLANET_FIELDS = [
+        'epoch_of_elements', 'orbital_inclination', 'longitude_of_ascending_node', 'argument_of_perihelion',
+        'mean_distance', 'eccentricity', 'mean_anomaly', 'daily_motion'
+    ]
+    SATELLITE_FIELDS = [
+        'diff_altitude_rate', 'diff_azimuth_rate', 'diff_altitude_acceleration', 'diff_azimuth_acceleration',
+        'diff_epoch', 'altitude', 'azimuth'
+    ]
+    # Base fields
+    telescopes = serializers.SlugRelatedField(
+        slug_field='id', queryset=Telescope.objects.all(), many=True, allow_null=True
+    )
+    start = serializers.DateTimeField(required=True)
+    end = serializers.DateTimeField(required=True)
+    # Constraints
+    max_airmass = serializers.FloatField(
+        min_value=1.0, max_value=25.0, default=2.0, required=False, help_text=_('Maximum acceptable airmass')
+    )
+    max_lunar_phase = serializers.FloatField(
+        min_value=0.0, max_value=1.0, default=1.0, required=False,
+        help_text=_('Maximum acceptable lunar phase fraction from 0 (new moon) to 1 (full moon)')
+    )
+    min_lunar_distance = serializers.FloatField(
+        min_value=0.0, max_value=180.0, default=0.0, required=False,
+        help_text=_('Minimum acceptable angular separation between the target and moon in decimal degrees')
+    )
+
+    # Target params
+    target_type = serializers.CharField(
+        read_only=True, allow_blank=True, help_text=_('Type of target set by serializer')
+    )
+    ## ra/dec ICRS targets
+    ra = serializers.FloatField(
+        min_value=0.0, max_value=360.0, required=False, help_text=_('Right Ascension in decimal degrees')
+    )
+    dec = serializers.FloatField(
+        min_value=-90.0, max_value=90.0, required=False, help_text=_('Declination in decimal degrees')
+    )
+    proper_motion_ra = serializers.FloatField(
+        min_value=-20000.0, max_value=20000.0, required=False,
+        label=_('Right Ascience Proper Motion mas/yr'),
+        help_text=_('Right Ascension Proper Motion of the target in mas/yr')
+    )
+    proper_motion_dec = serializers.FloatField(
+        min_value=-20000.0, max_value=20000.0, required=False,
+        label=_('Declination Proper Motion mas/yr'),
+        help_text=_('Declination Proper Motion of the target in mas/yr')
+    )
+    parallax = serializers.FloatField(
+        min_value=-2000.0, max_value=2000.0, required=False,
+        help_text=_('Parallax of the target in mas, up to 2000.0')
+    )
+    epoch = serializers.FloatField(max_value=2100.0, default=2000.0, required=False, help_text=_('Epoch in MJD'))
+
+    ## hour_angle/dec targets
+    hour_angle = serializers.FloatField(required=False, help_text=_('Hour angle of the target'))
+
+    ## altitude/azimuth (satellite) targets
+    altitude = serializers.FloatField(
+        min_value=0.0, max_value=90.0, required=False, help_text=_('Altitude of the target')
+    )
+    azimuth = serializers.FloatField(
+        min_value=0.0, max_value=360.0, required=False, help_text=_('Azimuth of the target')
+    )
+    diff_altitude_rate = serializers.FloatField(
+        required=False,
+        help_text=_('Differential altitude rate in arcsec/s')
+    )
+    diff_azimuth_rate = serializers.FloatField(
+        required=False,
+        help_text=_('Differential azimuth rate in arcsec/s')
+    )
+    diff_epoch = serializers.FloatField(
+        required=False,
+        help_text=_('Reference time for non-sidereal motion in MJD')
+    )
+    diff_altitude_acceleration = serializers.FloatField(
+        required=False,
+        help_text=_('Differential altitude acceleration in arcsec/s^2')
+    )
+    diff_azimuth_acceleration = serializers.FloatField(
+        required=False,
+        help_text=_('Differential azimuth acceleration in arcsec/s^2')
+    )
+
+    ## Non-sidereal targets
+    epoch_of_elements = serializers.FloatField(
+        min_value=10000.0, max_value=100000.0, required=False,
+        help_text=_('The epoch of orbital elements (MJD)')
+    )
+    epoch_of_perihelion = serializers.FloatField(
+        min_value=361.0, max_value=240000.0, required=False,
+        help_text=_('The epoch of perihelion (MJD)')
+    )
+    orbital_inclination = serializers.FloatField(
+        min_value=0.0, max_value=180.0, required=False,
+        help_text=_('Orbital Inclination angle in decimal degrees')
+    )
+    longitude_of_ascending_node = serializers.FloatField(
+        min_value=0.0, max_value=360.0, required=False,
+        help_text=_('Longitude of Ascending Node angle in decimal degrees')
+    )
+    longitude_of_perihelion = serializers.FloatField(
+        min_value=0.0, max_value=360.0, required=False,
+        help_text=_('Longitude of Perihelion angle in degrees')
+    )
+    argument_of_perihelion = serializers.FloatField(
+        min_value=0.0, max_value=360.0, required=False,
+        help_text=_('Argument of Perihelion angle in degrees')
+    )
+    mean_distance = serializers.FloatField(
+        required=False, help_text=_('Mean distance in AU')
+    )
+    perihelion_distance = serializers.FloatField(
+        required=False, help_text=_('Perihelion distance in AU')
+    )
+    eccentricity = serializers.FloatField(
+        min_value=0.0, required=False,
+        help_text=_('Eccentricity of the orbit')
+    )
+    mean_anomaly = serializers.FloatField(
+        min_value=0.0, max_value=360.0, required=False, help_text=_('Mean Anomaly angle in degrees')
+    )
+    daily_motion = serializers.FloatField(
+        required=False, help_text=_('Daily Motion angle in degrees')
+    )
+
+    def validate(self, data):
+        validated_data = super().validate(data)
+        # If no specific telescopes were choosen, assume all will be used
+        if not validated_data.get('telescopes'):
+            validated_data['telescopes'] = list(Telescope.objects.all())
+
+        # Make sure that a valid target was submitted
+        if validated_data.get('ra') and validated_data.get('dec'):
+            validated_data['target_type'] = TargetTypes.ICRS.name
+        elif validated_data.get('hour_angle') and validated_data.get('dec'):
+            validated_data['target_type'] = TargetTypes.HOUR_ANGLE.name
+        elif validated_data.get('altitude') and validated_data.get('azimuth'):
+            validated_data['target_type'] = TargetTypes.SATELLITE.name
+            missing_fields = [field for field in self.SATELLITE_FIELDS if field not in validated_data]
+            if missing_fields:
+                raise serializers.ValidationError(
+                    {field: _('This field is required for altitude/azimuth targets') for field in missing_fields}
+                )
+        else:
+            # Check how many if any fields are missing from the orbital element types to see what error to return
+            missing_minor_planet_fields = [field for field in self.MINOR_PLANET_FIELDS if field not in validated_data]
+            missing_comet_fields = [field for field in self.COMET_FIELDS if field not in validated_data]
+            missing_major_planet_fields = [field for field in self.MAJOR_PLANET_FIELDS if field not in validated_data]
+            if len(missing_major_planet_fields) == 0:
+                validated_data['target_type'] = TargetTypes.JPL_MAJOR_PLANET.name
+            elif len(missing_minor_planet_fields) == 0:
+                validated_data['target_type'] = TargetTypes.MPC_MINOR_PLANET.name
+            elif len(missing_comet_fields) == 0:
+                validated_data['target_type'] = TargetTypes.MPC_COMET.name
+            else:
+                missing_minor = len(missing_minor_planet_fields)
+                missing_comet = len(missing_comet_fields)
+                missing_major = len(missing_major_planet_fields)
+                missing_fields = []
+                # We are missing some fields of an orbital element target or missing a target completely
+                if (missing_minor <= missing_comet and
+                    missing_minor <= missing_major and
+                    missing_minor < len(self.MINOR_PLANET_FIELDS)):
+                    missing_fields = missing_minor_planet_fields
+                    validated_data['target_type'] = TargetTypes.MPC_MINOR_PLANET.name
+                elif (missing_comet <= missing_minor and
+                      missing_comet <= missing_major and
+                      missing_comet < len(self.COMET_FIELDS)):
+                    missing_fields = missing_comet_fields
+                    validated_data['target_type'] = TargetTypes.MPC_COMET.name
+                elif (missing_major < len(self.MAJOR_PLANET_FIELDS)):
+                    missing_fields = missing_major_planet_fields
+                    validated_data['target_type'] = TargetTypes.JPL_MAJOR_PLANET.name
+                if missing_fields:
+                    raise serializers.ValidationError(
+                        {field: _(f'This field is required for {validated_data['target_type']} targets') for field in missing_fields}
+                    )
+                else:
+                    raise serializers.ValidationError(
+                        _('Must submit a valid target using either ra/dec, hour_angle/dec, altitude/azimuth, or orbital elements')
+                    )
+        return validated_data

--- a/heroic_api/serializers.py
+++ b/heroic_api/serializers.py
@@ -295,7 +295,7 @@ class TargetVisibilityQuerySerializer(serializers.Serializer):
                     validated_data['target_type'] = TargetTypes.JPL_MAJOR_PLANET.name
                 if missing_fields:
                     raise serializers.ValidationError(
-                        {field: _(f'This field is required for {validated_data['target_type']} targets') for field in missing_fields}
+                        {field: _(f'This field is required for {validated_data["target_type"]} targets') for field in missing_fields}
                     )
                 else:
                     raise serializers.ValidationError(

--- a/heroic_api/test/test_visibility.py
+++ b/heroic_api/test/test_visibility.py
@@ -3,7 +3,6 @@ from mixer.backend.django import mixer
 from django.contrib.auth.models import User
 from django.urls import reverse
 from datetime import datetime
-from urllib.parse import urlencode
 
 from heroic_api import models
 
@@ -131,3 +130,97 @@ class TestVisibilityIntervals(BaseVisibilityTestCase):
         intervals = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_filter_telescope_id(self):
+        query = self.m22_basic_target_query.copy()
+        query['telescopes'] = [self.telescope.id]
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T17:29:09.080298Z', '2025-03-01T19:00:37.291560Z']],
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_filter_airmass(self):
+        query = self.m22_basic_target_query.copy()
+        query['max_airmass'] = 1
+        # There are no intervals with airmass of 1 for this target
+        expected_intervals = {
+            self.telescope.id: [],
+            self.telescope2.id: []
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_dates_required(self):
+        query = self.m22_basic_target_query.copy()
+        del query['start']
+        del query['end']
+        response = self.client.get(reverse('api:visibility-intervals'), data=query)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('start', response.json())
+        self.assertIn('end', response.json())
+
+    def test_visibility_intervals_target_required(self):
+        query = self.m22_basic_target_query.copy()
+        del query['ra']
+        del query['dec']
+        response = self.client.get(reverse('api:visibility-intervals'), data=query)
+        self.assertContains(response, 'a valid target using either ra/dec', status_code=400)
+
+    def test_visibility_intervals_minor_planet_target_missing_fields(self):
+        query = self.minor_planet_target_query.copy()
+        del query['mean_distance']
+        del query['orbital_inclination']
+        response = self.client.get(reverse('api:visibility-intervals'), data=query)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('mean_distance', response.json())
+        self.assertIn('orbital_inclination', response.json())
+
+    def test_visibility_intervals_major_planet_target_missing_fields(self):
+        query = self.mars_target_query.copy()
+        del query['eccentricity']
+        del query['orbital_inclination']
+        response = self.client.get(reverse('api:visibility-intervals'), data=query)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('eccentricity', response.json())
+        self.assertIn('orbital_inclination', response.json())
+
+
+class TestVisibilityAirmass(BaseVisibilityTestCase):
+    def test_visibility_airmasses_basic_icrs_succeeds(self):
+        query = self.m22_basic_target_query.copy()
+        # constrain query so our expected values are shorter
+        query['telescopes'] = [self.telescope.id]
+        query['end'] = datetime(2025, 3, 1, 18)
+        expected_airmasses = {
+            self.telescope.id: {
+                'times': ['2025-03-01T17:29:09.080298+00:00', '2025-03-01T17:39:09.080298+00:00',
+                          '2025-03-01T17:49:09.080298+00:00', '2025-03-01T17:59:09.080298+00:00'],
+                'airmasses': [1.9987162221252022, 1.8809851094809273, 1.778227573468417, 1.6879817282310983]
+            }
+        }
+        response = self.client.get(reverse('api:visibility-airmass'), data=query)
+        airmasses = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_airmasses, airmasses)
+
+    def test_visibility_airmasses_minor_planet_succeeds(self):
+        query = self.minor_planet_target_query
+        # constrain query so our expected values are shorter
+        query['telescopes'] = [self.telescope.id]
+        query['end'] = datetime(2025, 3, 1, 10)
+        expected_airmasses = {
+            self.telescope.id: {
+                'times': ['2025-03-01T09:31:42.339675+00:00', '2025-03-01T09:41:42.339675+00:00',
+                          '2025-03-01T09:51:42.339675+00:00'],
+                'airmasses': [1.7703200219302355, 1.7567105747821408, 1.7478200356418352]
+            }
+        }
+        response = self.client.get(reverse('api:visibility-airmass'), data=query)
+        airmasses = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_airmasses, airmasses)

--- a/heroic_api/test/test_visibility.py
+++ b/heroic_api/test/test_visibility.py
@@ -91,6 +91,16 @@ class TestVisibilityIntervals(BaseVisibilityTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(expected_intervals, intervals)
 
+    def test_visibility_intervals_basic_icrs_succeeds_with_post(self):
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T17:29:09.080298Z', '2025-03-01T19:00:37.291560Z']],
+            self.telescope2.id: [['2025-03-01T08:11:29.401273Z', '2025-03-01T09:41:16.314638Z']]
+        }
+        response = self.client.post(reverse('api:visibility-intervals'), data=self.m22_basic_target_query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
     def test_visibility_intervals_full_icrs_succeeds(self):
         expected_intervals = {
             self.telescope.id: [['2025-03-01T17:29:09.114194Z', '2025-03-01T19:00:37.291560Z']],
@@ -204,6 +214,23 @@ class TestVisibilityAirmass(BaseVisibilityTestCase):
             }
         }
         response = self.client.get(reverse('api:visibility-airmass'), data=query)
+        airmasses = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_airmasses, airmasses)
+
+    def test_visibility_airmasses_basic_icrs_succeeds_with_post(self):
+        query = self.m22_basic_target_query.copy()
+        # constrain query so our expected values are shorter
+        query['telescopes'] = [self.telescope.id]
+        query['end'] = datetime(2025, 3, 1, 18)
+        expected_airmasses = {
+            self.telescope.id: {
+                'times': ['2025-03-01T17:29:09.080298+00:00', '2025-03-01T17:39:09.080298+00:00',
+                          '2025-03-01T17:49:09.080298+00:00', '2025-03-01T17:59:09.080298+00:00'],
+                'airmasses': [1.9987162221252022, 1.8809851094809273, 1.778227573468417, 1.6879817282310983]
+            }
+        }
+        response = self.client.post(reverse('api:visibility-airmass'), data=query)
         airmasses = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(expected_airmasses, airmasses)

--- a/heroic_api/test/test_visibility.py
+++ b/heroic_api/test/test_visibility.py
@@ -1,0 +1,133 @@
+from rest_framework.test import APITestCase
+from mixer.backend.django import mixer
+from django.contrib.auth.models import User
+from django.urls import reverse
+from datetime import datetime
+from urllib.parse import urlencode
+
+from heroic_api import models
+
+
+class BaseVisibilityTestCase(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = mixer.blend(User, is_superuser=False)
+        self.client.force_login(self.user)
+        self.observatory = mixer.blend(models.Observatory, id='tstObs', admin=self.user)
+        self.site = mixer.blend(models.Site, id=f'{self.observatory.id}.coj', observatory=self.observatory, elevation=3000)
+        self.telescope = mixer.blend(models.Telescope, id=f'{self.site.id}.2m0a', site=self.site,
+                                     latitude=-31.272932, longitude=149.070648, horizon=15.0,
+                                     positive_ha_limit=4.6, negative_ha_limit=-4.6, aperture=2.0)
+        self.site2 = mixer.blend(models.Site, id=f'{self.observatory.id}.lsc', observatory=self.observatory, elevation=3000)
+        self.telescope2 = mixer.blend(models.Telescope, id=f'{self.site2.id}.1m0a', site=self.site2,
+                                     latitude=-30.1674472222, longitude=-70.8046805556, horizon=15.0,
+                                     positive_ha_limit=4.6, negative_ha_limit=-4.6, aperture=1.0)
+        # M22 ra/dec
+        self.m22_basic_target_query = {
+            'start': datetime(2025, 3, 1).isoformat(),
+            'end': datetime(2025, 3, 2).isoformat(),
+            'ra': 279.09975,
+            'dec': -23.90475,
+            'max_airmass': 2
+        }
+        # M22 full ICRS
+        self.m22_full_target_query = {
+            'start': datetime(2025, 3, 1).isoformat(),
+            'end': datetime(2025, 3, 2).isoformat(),
+            'ra': 279.09975,
+            'dec': -23.90475,
+            'proper_motion_ra': 9.82,
+            'proper_motion_dec': -5.54,
+            'parallax': 0.306,
+            'max_airmass': 2
+        }
+        # MPC 19255        
+        self.minor_planet_target_query = {
+            'start': datetime(2025, 3, 1).isoformat(),
+            'end': datetime(2025, 3, 2).isoformat(),
+            'epoch_of_elements': 59600,
+            'orbital_inclination': 1.48467,
+            'longitude_of_ascending_node': 72.3357657,
+            'argument_of_perihelion': 119.49807,
+            'eccentricity': 0.0306641,
+            'mean_distance': 42.69391,
+            'mean_anomaly': 267.71107,
+            'max_airmass': 2
+        }
+        # MPC PJ99R28O        
+        self.comet_target_query = {
+            'start': datetime(2025, 3, 1).isoformat(),
+            'end': datetime(2025, 3, 2).isoformat(),
+            'epoch_of_elements': 56400,
+            'orbital_inclination': 8.18884,
+            'longitude_of_ascending_node': 148.3155371,
+            'argument_of_perihelion': 220.09003,
+            'eccentricity': 0.6529808,
+            'perihelion_distance': 1.2193886,
+            'epoch_of_perihelion': 56278.58647,
+            'max_airmass': 2
+        }
+        self.mars_target_query = {
+            'start': datetime(2025, 3, 1).isoformat(),
+            'end': datetime(2025, 3, 2).isoformat(),
+            'epoch_of_elements': 60181,
+            'orbital_inclination': 1.847919327404603,
+            'longitude_of_ascending_node': 49.48984370080841,
+            'argument_of_perihelion': 286.6396041587725,
+            'eccentricity': 0.09334416606027193,
+            'mean_distance': 1.52369752919589,
+            'mean_anomaly': 225.1309151389929,
+            'daily_motion': 0.5240298172661463,
+            'max_airmass': 2
+        }
+
+class TestVisibilityIntervals(BaseVisibilityTestCase):
+    def test_visibility_intervals_basic_icrs_succeeds(self):
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T17:29:09.080298Z', '2025-03-01T19:00:37.291560Z']],
+            self.telescope2.id: [['2025-03-01T08:11:29.401273Z', '2025-03-01T09:41:16.314638Z']]
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=self.m22_basic_target_query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_full_icrs_succeeds(self):
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T17:29:09.114194Z', '2025-03-01T19:00:37.291560Z']],
+            self.telescope2.id: [['2025-03-01T08:11:29.435316Z', '2025-03-01T09:41:16.314638Z']]
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=self.m22_full_target_query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_minor_planet_succeeds(self):
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T09:31:42.339675Z', '2025-03-01T11:45:00Z']],
+            self.telescope2.id: [['2025-03-01T00:10:10.226436Z', '2025-03-01T02:30:00Z']]
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=self.minor_planet_target_query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_comet_succeeds(self):
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T16:15:00Z', '2025-03-01T19:00:37.291560Z']],
+            self.telescope2.id: [['2025-03-01T07:00:00Z', '2025-03-01T09:41:16.314638Z']]
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=self.comet_target_query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)
+
+    def test_visibility_intervals_major_planet_succeeds(self):
+        expected_intervals = {
+            self.telescope.id: [['2025-03-01T09:31:42.339675Z', '2025-03-01T11:45:00Z']],
+            self.telescope2.id: [['2025-03-01T00:10:10.226436Z', '2025-03-01T02:45:00Z']]
+        }
+        response = self.client.get(reverse('api:visibility-intervals'), data=self.mars_target_query)
+        intervals = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_intervals, intervals)

--- a/heroic_api/urls.py
+++ b/heroic_api/urls.py
@@ -1,9 +1,10 @@
 from django.urls import re_path, include
 from rest_framework.routers import DefaultRouter
-from .views import (
-    ObservatoryViewSet, SiteViewSet, TelescopeViewSet, ProfileAPIView,
+from heroic_api.viewsets import (
+    ObservatoryViewSet, SiteViewSet, TelescopeViewSet,
     InstrumentViewSet, TelescopeStatusViewSet, InstrumentCapabilityViewSet
 )
+from heroic_api.views import ProfileAPIView, TargetVisibilityAPIView, TargetAirmassAPIView
 
 
 router = DefaultRouter()
@@ -17,4 +18,6 @@ router.register(r'instrument-capabilities', InstrumentCapabilityViewSet)
 urlpatterns = [
     re_path(r'^', include(router.urls)),
     re_path(r'profile', ProfileAPIView.as_view()),
+    re_path(r'visibility/intervals', TargetVisibilityAPIView.as_view(), name='visibility-intervals'),
+    re_path(r'visibility/airmass', TargetAirmassAPIView.as_view(), name='visibility-airmass'),
 ]

--- a/heroic_api/views.py
+++ b/heroic_api/views.py
@@ -1,17 +1,13 @@
-from rest_framework import viewsets
+from rest_framework.views import APIView
 from rest_framework.generics import RetrieveUpdateAPIView
-from rest_framework.decorators import action
-from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework import status
+
 from django.contrib.auth.models import User
 
-from heroic_api.models import Observatory, Site, Telescope, Instrument, TelescopeStatus, InstrumentCapability
-from heroic_api.serializers import (
-    ObservatorySerializer, SiteSerializer, TelescopeSerializer, ProfileSerializer,
-    InstrumentSerializer, TelescopeStatusSerializer, InstrumentCapabilitySerializer
-)
-from heroic_api.permissions import IsObservatoryAdminOrReadOnly, IsAdminOrReadOnly
+from heroic_api.serializers import ProfileSerializer, TargetVisibilityQuerySerializer
+from heroic_api.visibility import get_rise_set_intervals_by_telescope_for_target, get_airmass_by_telescope_for_target
 
 
 class ProfileAPIView(RetrieveUpdateAPIView):
@@ -26,67 +22,23 @@ class ProfileAPIView(RetrieveUpdateAPIView):
         return qs.first().profile
 
 
-class ObservatoryViewSet(viewsets.ModelViewSet):
-    queryset = Observatory.objects.all()
-    serializer_class = ObservatorySerializer
-    permission_classes = [IsAdminOrReadOnly]
+class TargetVisibilityAPIView(APIView):
+    def get(self, request):
+        serializer = TargetVisibilityQuerySerializer(data=request.query_params)
+        if serializer.is_valid():
+            data = serializer.validated_data
+            visibility_intervals = get_rise_set_intervals_by_telescope_for_target(data)
+            return Response(visibility_intervals, status=status.HTTP_200_OK)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class SiteViewSet(viewsets.ModelViewSet):
-    queryset = Site.objects.all()
-    serializer_class = SiteSerializer
-    permission_classes = [IsObservatoryAdminOrReadOnly]
-
-
-class TelescopeViewSet(viewsets.ModelViewSet):
-    queryset = Telescope.objects.all()
-    serializer_class = TelescopeSerializer
-    permission_classes = [IsObservatoryAdminOrReadOnly]
-
-    @action(detail=True, methods=['get', 'post'])
-    def status(self, request, pk=None):
-        if request.method == 'GET':
-            serializer = TelescopeStatusSerializer(self.get_object().statuses.all(), many=True)
-            return Response(data=serializer.data, status=status.HTTP_200_OK)
-        elif request.method == 'POST':
-            data = request.data
-            data['telescope'] = pk
-            serializer = TelescopeStatusSerializer(data=data, many=isinstance(data, list))
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            else:
-                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class InstrumentViewSet(viewsets.ModelViewSet):
-    queryset = Instrument.objects.all()
-    serializer_class = InstrumentSerializer
-    permission_classes = [IsObservatoryAdminOrReadOnly]
-
-    @action(detail=True, methods=['get', 'post'])
-    def capabilities(self, request, pk=None):
-        if request.method == 'GET':
-            serializer = InstrumentCapabilitySerializer(self.get_object().capabilities.all(), many=True)
-            return Response(data=serializer.data, status=status.HTTP_200_OK)
-        elif request.method == 'POST':
-            data = request.data
-            data['instrument'] = pk
-            serializer = InstrumentCapabilitySerializer(data=data, many=isinstance(data, list))
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            else:
-                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class TelescopeStatusViewSet(viewsets.ModelViewSet):
-    queryset = TelescopeStatus.objects.all()
-    serializer_class = TelescopeStatusSerializer
-    permission_classes = [IsObservatoryAdminOrReadOnly]
-
-
-class InstrumentCapabilityViewSet(viewsets.ModelViewSet):
-    queryset = InstrumentCapability.objects.all()
-    serializer_class = InstrumentCapabilitySerializer
-    permission_classes = [IsObservatoryAdminOrReadOnly]
+class TargetAirmassAPIView(APIView):
+    def get(self, request):
+        serializer = TargetVisibilityQuerySerializer(data=request.query_params)
+        if serializer.is_valid():
+            data = serializer.validated_data
+            airmass_data = get_airmass_by_telescope_for_target(data)
+            return Response(airmass_data, status=status.HTTP_200_OK)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/heroic_api/views.py
+++ b/heroic_api/views.py
@@ -22,9 +22,14 @@ class ProfileAPIView(RetrieveUpdateAPIView):
         return qs.first().profile
 
 
+
+
 class TargetVisibilityAPIView(APIView):
-    def get(self, request):
-        serializer = TargetVisibilityQuerySerializer(data=request.query_params)
+    """ A API view to get visiblity intervals for targets on telescopes
+        Supports being called through POST with a data dict or GET with query params
+    """
+    def get_visibility(self, data):
+        serializer = TargetVisibilityQuerySerializer(data=data)
         if serializer.is_valid():
             data = serializer.validated_data
             visibility_intervals = get_rise_set_intervals_by_telescope_for_target(data)
@@ -32,13 +37,28 @@ class TargetVisibilityAPIView(APIView):
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    def get(self, request):
+        return self.get_visibility(request.query_params)
+
+    def post(self, request):
+        return self.get_visibility(request.data)
+
 
 class TargetAirmassAPIView(APIView):
-    def get(self, request):
-        serializer = TargetVisibilityQuerySerializer(data=request.query_params)
+    """ A API view to get airmasses for targets on telescopes at times
+        Supports being called through POST with a data dict or GET with query params
+    """
+    def get_airmass(self, data):
+        serializer = TargetVisibilityQuerySerializer(data=data)
         if serializer.is_valid():
             data = serializer.validated_data
             airmass_data = get_airmass_by_telescope_for_target(data)
             return Response(airmass_data, status=status.HTTP_200_OK)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def get(self, request):
+        return self.get_airmass(request.query_params)
+
+    def post(self, request):
+        return self.get_airmass(request.data)

--- a/heroic_api/viewsets.py
+++ b/heroic_api/viewsets.py
@@ -1,0 +1,77 @@
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework import status
+
+from heroic_api.models import Observatory, Site, Telescope, Instrument, TelescopeStatus, InstrumentCapability
+from heroic_api.serializers import (
+    ObservatorySerializer, SiteSerializer, TelescopeSerializer,
+    InstrumentSerializer, TelescopeStatusSerializer, InstrumentCapabilitySerializer
+)
+from heroic_api.permissions import IsObservatoryAdminOrReadOnly, IsAdminOrReadOnly
+
+
+class ObservatoryViewSet(viewsets.ModelViewSet):
+    queryset = Observatory.objects.all()
+    serializer_class = ObservatorySerializer
+    permission_classes = [IsAdminOrReadOnly]
+
+
+class SiteViewSet(viewsets.ModelViewSet):
+    queryset = Site.objects.all()
+    serializer_class = SiteSerializer
+    permission_classes = [IsObservatoryAdminOrReadOnly]
+
+
+class TelescopeViewSet(viewsets.ModelViewSet):
+    queryset = Telescope.objects.all()
+    serializer_class = TelescopeSerializer
+    permission_classes = [IsObservatoryAdminOrReadOnly]
+
+    @action(detail=True, methods=['get', 'post'])
+    def status(self, request, pk=None):
+        if request.method == 'GET':
+            serializer = TelescopeStatusSerializer(self.get_object().statuses.all(), many=True)
+            return Response(data=serializer.data, status=status.HTTP_200_OK)
+        elif request.method == 'POST':
+            data = request.data
+            data['telescope'] = pk
+            serializer = TelescopeStatusSerializer(data=data, many=isinstance(data, list))
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            else:
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class InstrumentViewSet(viewsets.ModelViewSet):
+    queryset = Instrument.objects.all()
+    serializer_class = InstrumentSerializer
+    permission_classes = [IsObservatoryAdminOrReadOnly]
+
+    @action(detail=True, methods=['get', 'post'])
+    def capabilities(self, request, pk=None):
+        if request.method == 'GET':
+            serializer = InstrumentCapabilitySerializer(self.get_object().capabilities.all(), many=True)
+            return Response(data=serializer.data, status=status.HTTP_200_OK)
+        elif request.method == 'POST':
+            data = request.data
+            data['instrument'] = pk
+            serializer = InstrumentCapabilitySerializer(data=data, many=isinstance(data, list))
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            else:
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class TelescopeStatusViewSet(viewsets.ModelViewSet):
+    queryset = TelescopeStatus.objects.all()
+    serializer_class = TelescopeStatusSerializer
+    permission_classes = [IsObservatoryAdminOrReadOnly]
+
+
+class InstrumentCapabilityViewSet(viewsets.ModelViewSet):
+    queryset = InstrumentCapability.objects.all()
+    serializer_class = InstrumentCapabilitySerializer
+    permission_classes = [IsObservatoryAdminOrReadOnly]

--- a/heroic_api/visibility.py
+++ b/heroic_api/visibility.py
@@ -45,7 +45,9 @@ def get_rise_set_intervals_by_telescope_for_target(data: dict) -> dict:
                 ),
                 moon_phase=data.get('max_lunar_phase', 1.0)
             )
-            intervals_by_telescope[telescope.id] = target_intervals
+            # Use the intervals library to coaslesce adjacent intervals for non-sidereal targets since they are sampled
+            # Will probably use more things in Intervals later to intersect/union intervals together
+            intervals_by_telescope[telescope.id] = Intervals(target_intervals).toTupleList()
         except MovingViolation:
             pass
                 

--- a/heroic_api/visibility.py
+++ b/heroic_api/visibility.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from heroic_api.models import Telescope, TargetTypes
 
 from rise_set.astrometry import (
-    make_ra_dec_target, make_satellite_target, make_hour_angle_target, make_minor_planet_target,
+    make_ra_dec_target, make_minor_planet_target,
     make_comet_target, make_major_planet_target, calculate_airmass_at_times
 )
 from rise_set.angle import Angle
@@ -102,36 +102,16 @@ def get_proper_motion(target_dict: dict):
 
 def get_rise_set_target(target_dict: dict):
     # The data in the dict should contain target_type which has been filled in with inferred type of the target
-    if target_dict['target_type'] in [TargetTypes.ICRS.name, TargetTypes.HOUR_ANGLE.name]:
+    if target_dict['target_type'] == TargetTypes.ICRS.name:
         pm = get_proper_motion(target_dict)
-        if target_dict['target_type'] == TargetTypes.ICRS.name:
-            return make_ra_dec_target(
-                ra=Angle(degrees=target_dict['ra']),
-                dec=Angle(degrees=target_dict['dec']),
-                ra_proper_motion=pm['pmra'],
-                dec_proper_motion=pm['pmdec'],
-                parallax=target_dict.get('parallax', 0.0),
-                rad_vel=0.0,
-                epoch=target_dict['epoch']
-            )
-        elif target_dict['target_type'] == TargetTypes.HOUR_ANGLE.name:
-            return make_hour_angle_target(
-                hour_angle=Angle(degrees=target_dict['hour_angle']),
-                dec=Angle(degrees=target_dict['dec']),
-                ra_proper_motion=pm['pmra'],
-                dec_proper_motion=pm['pmdec'],
-                parallax=target_dict.get('parallax', 0.0),
-                epoch=target_dict['epoch']
-            )
-    elif target_dict['target_type'] == TargetTypes.SATELLITE.name:
-        return make_satellite_target(
-            alt=target_dict['altitude'],
-            az=target_dict['azimuth'],
-            diff_alt_rate=target_dict['diff_altitude_rate'],
-            diff_az_rate=target_dict['diff_azimuth_rate'],
-            diff_alt_accel=target_dict['diff_altitude_acceleration'],
-            diff_az_accel=target_dict['diff_azimuth_acceleration'],
-            diff_epoch_rate=target_dict['diff_epoch']
+        return make_ra_dec_target(
+            ra=Angle(degrees=target_dict['ra']),
+            dec=Angle(degrees=target_dict['dec']),
+            ra_proper_motion=pm['pmra'],
+            dec_proper_motion=pm['pmdec'],
+            parallax=target_dict.get('parallax', 0.0),
+            rad_vel=0.0,
+            epoch=target_dict['epoch']
         )
     elif target_dict['target_type'] == TargetTypes.MPC_MINOR_PLANET.name:
         return make_minor_planet_target(

--- a/heroic_api/visibility.py
+++ b/heroic_api/visibility.py
@@ -1,0 +1,205 @@
+from math import cos, radians
+from datetime import datetime, timedelta
+
+from heroic_api.models import Telescope, TargetTypes
+
+from rise_set.astrometry import (
+    make_ra_dec_target, make_satellite_target, make_hour_angle_target, make_minor_planet_target,
+    make_comet_target, make_major_planet_target, calculate_airmass_at_times
+)
+from rise_set.angle import Angle
+from rise_set.rates import ProperMotion
+from rise_set.visibility import Visibility
+from rise_set.exceptions import MovingViolation
+from time_intervals.intervals import Intervals
+
+HOURS_PER_DEGREES = 15.0
+
+
+def get_rise_set_intervals_by_telescope_for_target(data: dict) -> dict:
+    """Get rise_set intervals by telescope for a target visibility request
+
+    Computes the intervals only if they do not already exist in cache.
+
+    Parameters:
+        data: The validated data from the TargetVisibilityQuerySerializer
+    Returns:
+        rise_set intervals by telescope
+    """
+    start = data['start']
+    end = data['end']
+    intervals_by_telescope = {}
+    rise_set_target = get_rise_set_target(data)
+
+    for telescope in data['telescopes']:
+        intervals_by_telescope[telescope.id] = []
+        rise_set_site = get_rise_set_site(telescope)
+        visibility = get_rise_set_visibility(rise_set_site, start, end, telescope)
+        target_intervals = Intervals()
+        try:
+            target_intervals = visibility.get_observable_intervals(
+                rise_set_target,
+                airmass=data['max_airmass'],
+                moon_distance=Angle(
+                    degrees=data['min_lunar_distance']
+                ),
+                moon_phase=data.get('max_lunar_phase', 1.0)
+            )
+            intervals_by_telescope[telescope.id] = target_intervals
+        except MovingViolation:
+            pass
+                
+    return intervals_by_telescope
+
+
+def get_rise_set_site(telescope: Telescope):
+    return {
+        'latitude': Angle(degrees=telescope.latitude),
+        'longitude': Angle(degrees=telescope.longitude),
+        'horizon': Angle(degrees=telescope.horizon),
+        'ha_limit_neg': Angle(degrees=telescope.negative_ha_limit * HOURS_PER_DEGREES),
+        'ha_limit_pos': Angle(degrees=telescope.positive_ha_limit * HOURS_PER_DEGREES)
+    }
+
+
+def get_rise_set_visibility(rise_set_site: dict, start: datetime, end: datetime, telescope: Telescope):
+    # Get rise set Visibility class for a site/telescope location and date range
+    return Visibility(
+        site=rise_set_site,
+        start_date=start,
+        end_date=end,
+        horizon=telescope.horizon,
+        ha_limit_neg=telescope.negative_ha_limit,
+        ha_limit_pos=telescope.positive_ha_limit,
+        zenith_blind_spot=telescope.zenith_blind_spot,
+        twilight='nautical'
+    )
+
+
+def get_proper_motion(target_dict: dict):
+    # This applies to the conversion of proper motion as specified by dividing out the cos dec term
+    # and converting from mas/yr to as/yr
+    # The proper motion fields are sometimes not present in HOUR_ANGLE targets
+    pm = {'pmra': None, 'pmdec': None}
+    if 'proper_motion_ra' in target_dict and target_dict['proper_motion_ra']:
+        pm['pmra'] = ProperMotion(
+            Angle(
+                degrees=(target_dict['proper_motion_ra'] / 1000.0 / cos(radians(target_dict['dec']))) / 3600.0,
+                units='arc'
+            ),
+            time='year'
+        )
+    if 'proper_motion_dec' in target_dict and target_dict['proper_motion_dec']:
+        pm['pmdec'] = ProperMotion(
+            Angle(
+                degrees=(target_dict['proper_motion_dec'] / 1000.0) / 3600.0,
+                units='arc'
+            ),
+            time='year'
+        )
+    return pm
+
+
+def get_rise_set_target(target_dict: dict):
+    # The data in the dict should contain target_type which has been filled in with inferred type of the target
+    if target_dict['target_type'] in [TargetTypes.ICRS.name, TargetTypes.HOUR_ANGLE.name]:
+        pm = get_proper_motion(target_dict)
+        if target_dict['target_type'] == TargetTypes.ICRS.name:
+            return make_ra_dec_target(
+                ra=Angle(degrees=target_dict['ra']),
+                dec=Angle(degrees=target_dict['dec']),
+                ra_proper_motion=pm['pmra'],
+                dec_proper_motion=pm['pmdec'],
+                parallax=target_dict.get('parallax', 0.0),
+                rad_vel=0.0,
+                epoch=target_dict['epoch']
+            )
+        elif target_dict['target_type'] == TargetTypes.HOUR_ANGLE.name:
+            return make_hour_angle_target(
+                hour_angle=Angle(degrees=target_dict['hour_angle']),
+                dec=Angle(degrees=target_dict['dec']),
+                ra_proper_motion=pm['pmra'],
+                dec_proper_motion=pm['pmdec'],
+                parallax=target_dict.get('parallax', 0.0),
+                epoch=target_dict['epoch']
+            )
+    elif target_dict['target_type'] == TargetTypes.SATELLITE.name:
+        return make_satellite_target(
+            alt=target_dict['altitude'],
+            az=target_dict['azimuth'],
+            diff_alt_rate=target_dict['diff_altitude_rate'],
+            diff_az_rate=target_dict['diff_azimuth_rate'],
+            diff_alt_accel=target_dict['diff_altitude_acceleration'],
+            diff_az_accel=target_dict['diff_azimuth_acceleration'],
+            diff_epoch_rate=target_dict['diff_epoch']
+        )
+    elif target_dict['target_type'] == TargetTypes.MPC_MINOR_PLANET.name:
+        return make_minor_planet_target(
+            target_type=target_dict['target_type'],
+            epoch=target_dict['epoch_of_elements'],
+            inclination=target_dict['orbital_inclination'],
+            long_node=target_dict['longitude_of_ascending_node'],
+            arg_perihelion=target_dict['argument_of_perihelion'],
+            semi_axis=target_dict['mean_distance'],
+            eccentricity=target_dict['eccentricity'],
+            mean_anomaly=target_dict['mean_anomaly']
+        )
+    elif target_dict['target_type'] == TargetTypes.MPC_COMET.name:
+        return make_comet_target(
+            target_type=target_dict['target_type'],
+            epoch=target_dict['epoch_of_elements'],
+            epochofperih=target_dict['epoch_of_perihelion'],
+            inclination=target_dict['orbital_inclination'],
+            long_node=target_dict['longitude_of_ascending_node'],
+            arg_perihelion=target_dict['argument_of_perihelion'],
+            perihdist=target_dict['perihelion_distance'],
+            eccentricity=target_dict['eccentricity'],
+        )
+    elif target_dict['target_type'] == TargetTypes.JPL_MAJOR_PLANET.name:
+        return make_major_planet_target(
+            target_type=target_dict['target_type'],
+            epochofel=target_dict['epoch_of_elements'],
+            inclination=target_dict['orbital_inclination'],
+            long_node=target_dict['longitude_of_ascending_node'],
+            arg_perihelion=target_dict['argument_of_perihelion'],
+            semi_axis=target_dict['mean_distance'],
+            eccentricity=target_dict['eccentricity'],
+            mean_anomaly=target_dict['mean_anomaly'],
+            dailymot=target_dict['daily_motion']
+        )
+    else:
+        raise TypeError('Invalid target type' + target_dict['type'])
+
+
+def date_range_for_interval(start: datetime, end: datetime, delta_time=timedelta(minutes=10)):
+    time = start
+    while time < end:
+        yield time
+        time += delta_time
+
+
+def get_airmass_by_telescope_for_target(data: dict) -> dict:
+    airmass_data = {}
+    visibility_intervals = get_rise_set_intervals_by_telescope_for_target(data)
+    rise_set_target = get_rise_set_target(data)
+    for telescope in data['telescopes']:
+        if telescope.id in visibility_intervals:
+            night_times = []
+            # Expand the visibility intervals into a list of datetimes sampled through the intervals
+            for interval in visibility_intervals[telescope.id]:
+                night_times.extend(
+                    [time for time in date_range_for_interval(interval[0], interval[1])]
+                )
+            if len(night_times) > 0:
+                airmass_data[telescope.id] = {
+                    'times': [time.isoformat() for time in night_times]
+                }
+                # Calculate airmass values at sampled datetimes
+                latitude = Angle(degrees=telescope.latitude)
+                longitude = Angle(degrees=telescope.longitude)
+                altitude = telescope.site.elevation
+                airmasses = calculate_airmass_at_times(
+                    night_times, rise_set_target, latitude, longitude, altitude
+                )
+                airmass_data[telescope.id]['airmasses'] = airmasses
+    return airmass_data

--- a/poetry.lock
+++ b/poetry.lock
@@ -658,6 +658,17 @@ pycodestyle = ">=2.12.0,<2.13.0"
 pyflakes = ">=3.2.0,<3.3.0"
 
 [[package]]
+name = "future"
+version = "0.18.3"
+description = "Clean single-source support for Python 3 and 2"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+groups = ["main"]
+files = [
+    {file = "future-0.18.3.tar.gz", hash = "sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"},
+]
+
+[[package]]
 name = "hop-client"
 version = "0.11.0"
 description = "A pub-sub client library for Multi-messenger Astrophysics"
@@ -764,6 +775,87 @@ josepy = "*"
 requests = "*"
 
 [[package]]
+name = "numpy"
+version = "2.2.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "numpy-2.2.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8146f3550d627252269ac42ae660281d673eb6f8b32f113538e0cc2a9aed42b9"},
+    {file = "numpy-2.2.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e642d86b8f956098b564a45e6f6ce68a22c2c97a04f5acd3f221f57b8cb850ae"},
+    {file = "numpy-2.2.4-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:a84eda42bd12edc36eb5b53bbcc9b406820d3353f1994b6cfe453a33ff101775"},
+    {file = "numpy-2.2.4-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:4ba5054787e89c59c593a4169830ab362ac2bee8a969249dc56e5d7d20ff8df9"},
+    {file = "numpy-2.2.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7716e4a9b7af82c06a2543c53ca476fa0b57e4d760481273e09da04b74ee6ee2"},
+    {file = "numpy-2.2.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adf8c1d66f432ce577d0197dceaac2ac00c0759f573f28516246351c58a85020"},
+    {file = "numpy-2.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:218f061d2faa73621fa23d6359442b0fc658d5b9a70801373625d958259eaca3"},
+    {file = "numpy-2.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:df2f57871a96bbc1b69733cd4c51dc33bea66146b8c63cacbfed73eec0883017"},
+    {file = "numpy-2.2.4-cp310-cp310-win32.whl", hash = "sha256:a0258ad1f44f138b791327961caedffbf9612bfa504ab9597157806faa95194a"},
+    {file = "numpy-2.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:0d54974f9cf14acf49c60f0f7f4084b6579d24d439453d5fc5805d46a165b542"},
+    {file = "numpy-2.2.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e9e0a277bb2eb5d8a7407e14688b85fd8ad628ee4e0c7930415687b6564207a4"},
+    {file = "numpy-2.2.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9eeea959168ea555e556b8188da5fa7831e21d91ce031e95ce23747b7609f8a4"},
+    {file = "numpy-2.2.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:bd3ad3b0a40e713fc68f99ecfd07124195333f1e689387c180813f0e94309d6f"},
+    {file = "numpy-2.2.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cf28633d64294969c019c6df4ff37f5698e8326db68cc2b66576a51fad634880"},
+    {file = "numpy-2.2.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fa8fa7697ad1646b5c93de1719965844e004fcad23c91228aca1cf0800044a1"},
+    {file = "numpy-2.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4162988a360a29af158aeb4a2f4f09ffed6a969c9776f8f3bdee9b06a8ab7e5"},
+    {file = "numpy-2.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:892c10d6a73e0f14935c31229e03325a7b3093fafd6ce0af704be7f894d95687"},
+    {file = "numpy-2.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db1f1c22173ac1c58db249ae48aa7ead29f534b9a948bc56828337aa84a32ed6"},
+    {file = "numpy-2.2.4-cp311-cp311-win32.whl", hash = "sha256:ea2bb7e2ae9e37d96835b3576a4fa4b3a97592fbea8ef7c3587078b0068b8f09"},
+    {file = "numpy-2.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:f7de08cbe5551911886d1ab60de58448c6df0f67d9feb7d1fb21e9875ef95e91"},
+    {file = "numpy-2.2.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a7b9084668aa0f64e64bd00d27ba5146ef1c3a8835f3bd912e7a9e01326804c4"},
+    {file = "numpy-2.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dbe512c511956b893d2dacd007d955a3f03d555ae05cfa3ff1c1ff6df8851854"},
+    {file = "numpy-2.2.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:bb649f8b207ab07caebba230d851b579a3c8711a851d29efe15008e31bb4de24"},
+    {file = "numpy-2.2.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:f34dc300df798742b3d06515aa2a0aee20941c13579d7a2f2e10af01ae4901ee"},
+    {file = "numpy-2.2.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f7ac96b16955634e223b579a3e5798df59007ca43e8d451a0e6a50f6bfdfba"},
+    {file = "numpy-2.2.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f92084defa704deadd4e0a5ab1dc52d8ac9e8a8ef617f3fbb853e79b0ea3592"},
+    {file = "numpy-2.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4e84a6283b36632e2a5b56e121961f6542ab886bc9e12f8f9818b3c266bfbb"},
+    {file = "numpy-2.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:11c43995255eb4127115956495f43e9343736edb7fcdb0d973defd9de14cd84f"},
+    {file = "numpy-2.2.4-cp312-cp312-win32.whl", hash = "sha256:65ef3468b53269eb5fdb3a5c09508c032b793da03251d5f8722b1194f1790c00"},
+    {file = "numpy-2.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:2aad3c17ed2ff455b8eaafe06bcdae0062a1db77cb99f4b9cbb5f4ecb13c5146"},
+    {file = "numpy-2.2.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cf4e5c6a278d620dee9ddeb487dc6a860f9b199eadeecc567f777daace1e9e7"},
+    {file = "numpy-2.2.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1974afec0b479e50438fc3648974268f972e2d908ddb6d7fb634598cdb8260a0"},
+    {file = "numpy-2.2.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:79bd5f0a02aa16808fcbc79a9a376a147cc1045f7dfe44c6e7d53fa8b8a79392"},
+    {file = "numpy-2.2.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:3387dd7232804b341165cedcb90694565a6015433ee076c6754775e85d86f1fc"},
+    {file = "numpy-2.2.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f527d8fdb0286fd2fd97a2a96c6be17ba4232da346931d967a0630050dfd298"},
+    {file = "numpy-2.2.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bce43e386c16898b91e162e5baaad90c4b06f9dcbe36282490032cec98dc8ae7"},
+    {file = "numpy-2.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31504f970f563d99f71a3512d0c01a645b692b12a63630d6aafa0939e52361e6"},
+    {file = "numpy-2.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:81413336ef121a6ba746892fad881a83351ee3e1e4011f52e97fba79233611fd"},
+    {file = "numpy-2.2.4-cp313-cp313-win32.whl", hash = "sha256:f486038e44caa08dbd97275a9a35a283a8f1d2f0ee60ac260a1790e76660833c"},
+    {file = "numpy-2.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:207a2b8441cc8b6a2a78c9ddc64d00d20c303d79fba08c577752f080c4007ee3"},
+    {file = "numpy-2.2.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8120575cb4882318c791f839a4fd66161a6fa46f3f0a5e613071aae35b5dd8f8"},
+    {file = "numpy-2.2.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a761ba0fa886a7bb33c6c8f6f20213735cb19642c580a931c625ee377ee8bd39"},
+    {file = "numpy-2.2.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:ac0280f1ba4a4bfff363a99a6aceed4f8e123f8a9b234c89140f5e894e452ecd"},
+    {file = "numpy-2.2.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:879cf3a9a2b53a4672a168c21375166171bc3932b7e21f622201811c43cdd3b0"},
+    {file = "numpy-2.2.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f05d4198c1bacc9124018109c5fba2f3201dbe7ab6e92ff100494f236209c960"},
+    {file = "numpy-2.2.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2f085ce2e813a50dfd0e01fbfc0c12bbe5d2063d99f8b29da30e544fb6483b8"},
+    {file = "numpy-2.2.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:92bda934a791c01d6d9d8e038363c50918ef7c40601552a58ac84c9613a665bc"},
+    {file = "numpy-2.2.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ee4d528022f4c5ff67332469e10efe06a267e32f4067dc76bb7e2cddf3cd25ff"},
+    {file = "numpy-2.2.4-cp313-cp313t-win32.whl", hash = "sha256:05c076d531e9998e7e694c36e8b349969c56eadd2cdcd07242958489d79a7286"},
+    {file = "numpy-2.2.4-cp313-cp313t-win_amd64.whl", hash = "sha256:188dcbca89834cc2e14eb2f106c96d6d46f200fe0200310fc29089657379c58d"},
+    {file = "numpy-2.2.4-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7051ee569db5fbac144335e0f3b9c2337e0c8d5c9fee015f259a5bd70772b7e8"},
+    {file = "numpy-2.2.4-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:ab2939cd5bec30a7430cbdb2287b63151b77cf9624de0532d629c9a1c59b1d5c"},
+    {file = "numpy-2.2.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0f35b19894a9e08639fd60a1ec1978cb7f5f7f1eace62f38dd36be8aecdef4d"},
+    {file = "numpy-2.2.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b4adfbbc64014976d2f91084915ca4e626fbf2057fb81af209c1a6d776d23e3d"},
+    {file = "numpy-2.2.4.tar.gz", hash = "sha256:9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f"},
+]
+
+[[package]]
+name = "ocs-rise-set"
+version = "0.6.4"
+description = "Routines for accurate rise/set/transit calculations"
+optional = false
+python-versions = "<3.13,>=3.9"
+groups = ["main"]
+files = [
+    {file = "ocs_rise_set-0.6.4-py3-none-any.whl", hash = "sha256:8e660c3f4dedf7cd372723549a58a02fd96c97946886df8a069752ec5640957f"},
+    {file = "ocs_rise_set-0.6.4.tar.gz", hash = "sha256:72ad3649aea6dc8e5edb8cb8b719a4e6615e6d941f18923485ddcf149beb6184"},
+]
+
+[package.dependencies]
+future = ">=0.18.3,<0.19.0"
+pyslalib = ">=1.0.10,<2.0.0"
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -815,6 +907,20 @@ files = [
     {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
     {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
 ]
+
+[[package]]
+name = "pyslalib"
+version = "1.0.10"
+description = "f2py and numpy based wrappers for SLALIB"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyslalib-1.0.10.tar.gz", hash = "sha256:da8663bdf9db51e345214a0add057ca7f52f7a892302044e8449b730dac1b085"},
+]
+
+[package.dependencies]
+numpy = ">=1.23"
 
 [[package]]
 name = "python-dateutil"
@@ -895,6 +1001,17 @@ files = [
 [package.extras]
 dev = ["build", "hatch"]
 doc = ["sphinx"]
+
+[[package]]
+name = "time-intervals"
+version = "1.0.0"
+description = "Operations on intervals"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "time_intervals-1.0.0.tar.gz", hash = "sha256:6d07984d4a6826311ebbf42022e86f3def26520c0448a24772eac87df661e152"},
+]
 
 [[package]]
 name = "toml"
@@ -1032,4 +1149,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.13"
-content-hash = "166f5d1bd10847a2788c656b4eac664bbf31933cff074cf195a613c1fb1f19a7"
+content-hash = "c85ddd0b829e31f5a71f969524208cfaf580f8b1a65cac94b2b1fc98af5595f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ dependencies = [
     "python-dateutil <3",
     "requests <3",
     "mozilla-django-oidc (>=4.0.1,<5.0.0)",
-    "hop-client (>=0.11.0,<1.0.0)"
+    "hop-client (>=0.11.0,<1.0.0)",
+    "ocs-rise-set (>=0.6.4,<0.7.0)",
+    "time-intervals (>=1.0.0,<2.0.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
This adds endpoints for `api/visibility/intervals` and `api/visibility/airmass` to get visibility intervals or airmass values for targets at telescopes in a time range. It's using the [rise_set](https://github.com/observatorycontrolsystem/rise_set) library LCO maintains for visibility calculations since its faster and better suited to large queries then the other python options out there. 

Right now it supports ICRS (ra/dec) targets or non-sidereal orbital elements based minor planets, major planets, or comets targets. It supports the constraints of airmass, lunar phase, and lunar angular separation distance. It can also be filtered by specific telescope. We will need to do more work once we get future planned telescope/instrument states to incorporate those outage times with the intervals returned.