### PR TITLE
Feature/UI login

### DIFF
--- a/heroic_api/middleware.py
+++ b/heroic_api/middleware.py
@@ -19,7 +19,7 @@ class SCiMMAAuthSessionRefresh:
         # Check the oidc token expiration - if expired, return a HTTP 401 to indicate client should logout
         oidc_expiration_seconds = request.session.get('oidc_id_token_expiration')
         if oidc_expiration_seconds:
-            if datetime.datetime.now(datetime.timezone.utc) > datetime.datetime.fromtimestamp(float(oidc_expiration_seconds)):
+            if datetime.datetime.now() > datetime.datetime.fromtimestamp(float(oidc_expiration_seconds)):
                 logger.debug(f"OIDC login has expired for user {request.user}, forcing logout and returning 401")
                 logout(request)
                 return HttpResponse('Unauthorized', status=401)

--- a/heroic_api/urls.py
+++ b/heroic_api/urls.py
@@ -4,7 +4,8 @@ from heroic_api.viewsets import (
     ObservatoryViewSet, SiteViewSet, TelescopeViewSet, TelescopePointingViewSet,
     InstrumentViewSet, TelescopeStatusViewSet, InstrumentCapabilityViewSet
 )
-from heroic_api.views import ProfileAPIView, TargetVisibilityAPIView, TargetAirmassAPIView
+from heroic_api.views import (ProfileAPIView, TargetVisibilityAPIView, TargetAirmassAPIView,
+                              RevokeApiTokenApiView)
 
 
 router = DefaultRouter()
@@ -19,6 +20,7 @@ router.register(r'instrument-capabilities', InstrumentCapabilityViewSet)
 urlpatterns = [
     re_path(r'^', include(router.urls)),
     re_path(r'profile', ProfileAPIView.as_view()),
+    re_path(r'revoke_api_token', RevokeApiTokenApiView.as_view(), name='revoke_api_token'),
     re_path(r'visibility/intervals', TargetVisibilityAPIView.as_view(), name='visibility-intervals'),
     re_path(r'visibility/airmass', TargetAirmassAPIView.as_view(), name='visibility-airmass'),
 ]

--- a/heroic_base/settings.py
+++ b/heroic_base/settings.py
@@ -167,7 +167,7 @@ SPECTACULAR_SETTINGS = {
     # OTHER SETTINGS
 }
 
-HEROIC_FRONT_END_BASE_URL = os.getenv('HEROIC_FRONT_END_BASE_URL', 'http://127.0.0.1:8000/')
+HEROIC_FRONT_END_BASE_URL = os.getenv('HEROIC_FRONT_END_BASE_URL', 'http://127.0.0.1:5173/')
 
 # Client ID (OIDC_RP_CLIENT_ID) and SECRET (OIDC_RP_CLIENT_SECRET)
 # are how HEROIC represents itself as the "relying party" (RP) to
@@ -202,8 +202,8 @@ SCIMMA_AUTH_USERNAME = os.getenv('SCIMMA_AUTH_USERNAME')
 SCIMMA_AUTH_PASSWORD = os.getenv('SCIMMA_AUTH_PASSWORD')
 
 LOGIN_URL = '/'  # This is the default redirect URL for user authentication tests
-LOGIN_REDIRECT_URL = HEROIC_FRONT_END_BASE_URL  # URL path to redirect to after login
-LOGOUT_REDIRECT_URL = HEROIC_FRONT_END_BASE_URL  # URL path to redirect to after logout
+LOGIN_REDIRECT_URL = '/login-redirect/'  # URL path to redirect to after login
+LOGOUT_REDIRECT_URL = '/logout-redirect/'  # URL path to redirect to after logout
 LOGIN_REDIRECT_URL_FAILURE = HEROIC_FRONT_END_BASE_URL  # TODO: create login failure page
 
 USE_X_FORWARDED_HOST = True

--- a/heroic_base/settings.py
+++ b/heroic_base/settings.py
@@ -209,6 +209,18 @@ LOGIN_REDIRECT_URL_FAILURE = HEROIC_FRONT_END_BASE_URL  # TODO: create login fai
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+CSRF_TRUSTED_ORIGINS = [
+    host.strip()
+    for host in os.getenv('DJANGO_CSRF_TRUSTED_ORIGINS', 'http://127.0.0.1:5173').split(',')
+    if host.strip()
+]
+CORS_ALLOWED_ORIGINS = [
+    host.strip()
+    for host in os.getenv('DJANGO_CORS_ALLOWED_ORIGINS', 'http://127.0.0.1:5173').split(',')
+    if host.strip()
+]
+CORS_ALLOW_CREDENTIALS = True
+
 try:
     from local_settings import *
 except ImportError:

--- a/heroic_base/settings.py
+++ b/heroic_base/settings.py
@@ -21,14 +21,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'asdfwea234asdf3wa')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DJANGO_DEBUG').lower() == 'true'
+DEBUG = os.getenv('DJANGO_DEBUG', 'true').lower() == 'true'
 
 ALLOWED_HOSTS = [
     host.strip()
-    for host in os.getenv('DJANGO_ALLOWED_HOSTS').split(',')
+    for host in os.getenv('DJANGO_ALLOWED_HOSTS', '').split(',')
     if host.strip()
 ]
 
@@ -92,10 +92,10 @@ WSGI_APPLICATION = 'heroic_base.wsgi.application'
 DATABASES = {
    'default': {
        'ENGINE': os.getenv('DB_ENGINE', 'django.contrib.gis.db.backends.postgis'),
-       'NAME': os.getenv('DB_NAME'),
-       'USER': os.getenv('DB_USER'),
-       'PASSWORD': os.getenv('DB_PASSWORD'),
-       'HOST': os.getenv('DB_HOST'),
+       'NAME': os.getenv('DB_NAME', 'heroic'),
+       'USER': os.getenv('DB_USER', 'postgres'),
+       'PASSWORD': os.getenv('DB_PASSWORD', 'postgres'),
+       'HOST': os.getenv('DB_HOST', '127.0.0.1'),
        'PORT': os.getenv('DB_PORT', '5432'),
    },
 }
@@ -174,9 +174,9 @@ HEROIC_FRONT_END_BASE_URL = os.getenv('HEROIC_FRONT_END_BASE_URL', 'http://127.0
 # the SCiMMA Keycloak instance (login.scimma.org) (the OP). They should
 # enter the environment as k8s secrets. Client ID and SECRET values were
 # obtained from Keycloak via SCiMMA/Chris Weaver.
-OIDC_RP_CLIENT_ID = os.getenv('OIDC_RP_CLIENT_ID')
-OIDC_RP_CLIENT_SECRET = os.getenv('OIDC_RP_CLIENT_SECRET')
-OIDC_RP_SIGN_ALGO = os.getenv('OIDC_RP_SIGN_ALGO')
+OIDC_RP_CLIENT_ID = os.getenv('OIDC_RP_CLIENT_ID', '')
+OIDC_RP_CLIENT_SECRET = os.getenv('OIDC_RP_CLIENT_SECRET', '')
+OIDC_RP_SIGN_ALGO = os.getenv('OIDC_RP_SIGN_ALGO', 'RS256')
 OIDC_STORE_ID_TOKEN = True  # Forces OIDC login to store oidc_id_token in session dict
 
 OIDC_OP_AUTHORIZATION_ENDPOINT = 'https://login.scimma.org/realms/SCiMMA/protocol/openid-connect/auth'
@@ -198,8 +198,8 @@ ALLOW_LOGOUT_GET_METHOD = True
 # SCIMMA_AUTH_BASE_URL = 'http://127.0.0.1:8000/hopauth'  # for local development of SCiMMA Auth (scimma_admin)
 # SCIMMA_AUTH_BASE_URL = 'https://my.hop.scimma.org/hopauth'  # for prod deployment of SCiMMA Auth (scimma_admin)
 SCIMMA_AUTH_BASE_URL = os.getenv('SCIMMA_AUTH_BASE_URL', 'https://admin.dev.hop.scimma.org/hopauth')  # for dev
-SCIMMA_AUTH_USERNAME = os.getenv('SCIMMA_AUTH_USERNAME')
-SCIMMA_AUTH_PASSWORD = os.getenv('SCIMMA_AUTH_PASSWORD')
+SCIMMA_AUTH_USERNAME = os.getenv('SCIMMA_AUTH_USERNAME', '')
+SCIMMA_AUTH_PASSWORD = os.getenv('SCIMMA_AUTH_PASSWORD', '')
 
 LOGIN_URL = '/'  # This is the default redirect URL for user authentication tests
 LOGIN_REDIRECT_URL = '/login-redirect/'  # URL path to redirect to after login

--- a/heroic_base/urls.py
+++ b/heroic_base/urls.py
@@ -17,10 +17,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, re_path, include
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+from heroic_api.views import LoginRedirectView, LogoutRedirectView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('auth/', include('mozilla_django_oidc.urls')),
+    path('login-redirect/', LoginRedirectView.as_view(), name='login-redirect'),
+    path('logout-redirect/', LogoutRedirectView.as_view(), name='logout-redirect'),
     re_path(r'^api/', include(('heroic_api.urls', 'api'), namespace='api')),  # Include heroic_api routes
     # drf-spectacular OpenAPI docs
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),


### PR DESCRIPTION
I've added some things for supporting login/logout through the frontend, including getting and revoking the API token once logged in.

This will require the following additional env variables to be set in the deployment with the frontends URL for all of them:

- DJANGO_CORS_ALLOWED_ORIGINS
- DJANGO_CSRF_TRUSTED_ORIGINS
- HEROIC_FRONT_END_BASE_URL

I've also added back defaults to all the env variable set settings so that you can run HEROIC locally for development without needing to override everything.