### PR TITLE
Fix the ingestor not launching, and the workers crashing irrecoverably

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,8 @@ RUN chmod +x /usr/local/bin/wait-for-db.sh
 # Set environment variable
 ENV DJANGO_SETTINGS_MODULE=heroic_base.settings
 
-# Expose port and define default entrypoint
+# Expose port and define default entrypoint. With no command, wait-for-db.sh launches
+# Gunicorn by default; pass a command (via compose `command:`) to run it instead, e.g.
+# `python manage.py readstreams`.
 EXPOSE 8000
 ENTRYPOINT ["/usr/local/bin/wait-for-db.sh"]
-CMD poetry run gunicorn \
-     --workers $GUNICORN_WORKERS \
-     --bind 0.0.0.0:8000 \
-     heroic_base.wsgi:application

--- a/heroic_api/tasks.py
+++ b/heroic_api/tasks.py
@@ -55,7 +55,7 @@ def poll_rubin_schedule():
                 instrument=instrument,
                 coordinate=point,
                 target=visit['target_name'],
-                defaults={'planned': False, 'extra': {'exposure_time': visit['t_exptime']}}
+                defaults={'planned': False, 'field': point.buffer(visit['s_fov']/2.0), 'extra': {'exposure_time': visit['t_exptime']}}
             )
         elif date > (datetime.now(timezone.utc) - timedelta(minutes=1)):
             # If this is in the future, i.e. a scheduled / planned visit, then collect them up to bulk add

--- a/heroic_api/tasks.py
+++ b/heroic_api/tasks.py
@@ -15,8 +15,11 @@ logger = logging.getLogger(__name__)
 RUBIN_TELESCOPE_ID='noirlab.cp.rubin'
 RUBIN_INSTRUMENT_ID='noirlab.cp.rubin.lsstcam'
 
+# Timeouts for the rubin schedule service. It fails and hangs alot
+RUBIN_REQUEST_TIMEOUT = (30, 120)
 
-@dramatiq.actor()
+
+@dramatiq.actor(max_retries=5, min_backoff=5000, max_backoff=300000, time_limit=360000)
 def poll_rubin_schedule():
     try:
         telescope = Telescope.objects.get(id=RUBIN_TELESCOPE_ID)
@@ -33,7 +36,7 @@ def poll_rubin_schedule():
     start = datetime.now() - timedelta(minutes=15)
     logger.info(f'Getting the Rubin schedule starting at {start.strftime('%Y-%m-%d %H:%M:%S')}')
     params = {'time': '25', 'start': start.strftime('%Y-%m-%d %H:%M:%S')}
-    response = requests.get(settings.RUBIN_SCHEDULE_URL, params=params)
+    response = requests.get(settings.RUBIN_SCHEDULE_URL, params=params, timeout=RUBIN_REQUEST_TIMEOUT)
     response.raise_for_status()
 
     visits = response.json()

--- a/wait-for-db.sh
+++ b/wait-for-db.sh
@@ -17,8 +17,15 @@ poetry run python manage.py migrate --noinput
 echo "🔄 Collecting static files…"
 poetry run python manage.py collectstatic --noinput
 
-echo "🚀 Starting Gunicorn"
-exec poetry run gunicorn \
-     --workers "${GUNICORN_WORKERS:-2}" \
-     --bind 0.0.0.0:8000 \
-     heroic_base.wsgi:application
+# If a command was passed (via Docker CMD / compose `command:`), run it. Otherwise
+# fall back to launching Gunicorn as the default.
+if [ "$#" -gt 0 ]; then
+  echo "🚀 Starting: $*"
+  exec poetry run "$@"
+else
+  echo "🚀 Starting Gunicorn"
+  exec poetry run gunicorn \
+       --workers "${GUNICORN_WORKERS:-2}" \
+       --bind 0.0.0.0:8000 \
+       heroic_base.wsgi:application
+fi


### PR DESCRIPTION
The ingestor containers have never been running - they have just been using the entrypoint (wait_for_db.sh) which then launches gunicorn, so the command to run readstreams never happened. I've changed the script to allow the command override to be used.

Also, the dramatiq worker has been in a crash state on prod for a few weeks. I think the root cause is massive hangs/timeouts in the Rubin schedule call sometimes that caused the worker thread to be unresponsive and die. Hopefully adding request timeouts below that threshold will prevent their service timeouts from taking down the worker.